### PR TITLE
Sphinx docs pipeline: manual build with auto-commit

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,11 +3,13 @@ name: Build Docs
 on:
   # push:
   #   branches: [main]
-  # workflow_call:
   workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: write
 
 jobs:
   build-docs:
@@ -17,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -41,10 +44,10 @@ jobs:
       - name: Build Doxygen docs
         run: cd docs/doxygen && doxygen Doxyfile
 
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: built-docs
-          path: |
-            public/docs
-            public/doxygen
+      - name: Commit and push built docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -f public/docs/ public/doxygen/
+          git diff --cached --quiet || git commit -m "chore: update built docs [skip ci]"
+          git push


### PR DESCRIPTION
## Summary

- `docs.yml` triggers manually, builds Sphinx + Doxygen, commits output back to `public/docs/` and `public/doxygen/` with `[skip ci]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)