### PR TITLE
docs: replace Doxygen with pymoose generate_references

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Install Sphinx dependencies
         run: pip install -r docs/requirements.txt
 
+      - name: Install pymoose and generate class references
+        run: |
+          pip install pymoose
+          python docs/source/generate_references.py
+
       - name: Build Sphinx docs
         env:
           MOOSE_CORE_PATH: ${{ github.workspace }}/docs/moose-core
@@ -38,16 +43,10 @@ jobs:
       - name: Add CNAME for docs subdomain
         run: echo "docs.mooseneuro.org" > public/docs/CNAME
 
-      - name: Install Doxygen
-        run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
-
-      - name: Build Doxygen docs
-        run: cd docs/doxygen && doxygen Doxyfile
-
       - name: Commit and push built docs
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -f public/docs/ public/doxygen/
+          git add -f public/docs/
           git diff --cached --quiet || git commit -m "chore: update built docs [skip ci]"
           git push

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ debug.log
 /.venv
 
 # docs build artifacts and temp files
+docs/source/references/
 docs/README.txt
 docs/_config.yml
 docs/config/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,3 @@ furo
 myst-parser
 sphinx-copybutton
 mock
-graphviz

--- a/src/content/workshops/onedayworkshop-kolkata2026.md
+++ b/src/content/workshops/onedayworkshop-kolkata2026.md
@@ -41,9 +41,14 @@ CHINTA, 2nd Floor, Tower 1, Bengal Eco Intelligent Park, Block EM, Sector V, Sal
 
 Researchers and students from neuroscience, systems biology, computational biology, computer science, physics, and researchers from industries who are interested in or working on computational modelling of biological systems.
 
-## Programme Schedule
+## Tentative Programme Schedule
 
-To be announced.
+  1. Introduction to Neuroscience.
+  2. Introduction to Jardesigner (GUI).
+  3. Hands-on with Jardesigner.
+  4. Installation and set-up of MOOSE.
+  5. Biophysical Neuronal Modeling (Lecture + Hands-on)
+  6. Simplified Neuronal Models and Neural Networks (Lecture + Hands-on)
 
 ## Funders
 
@@ -57,3 +62,5 @@ To be announced.
 ## Contact Information
 
 Email: mooseneuro@gmail.com
+
+> Please note that accommodation and travel expenses are not covered for this workshop.


### PR DESCRIPTION
- Remove Doxygen build steps from docs.yml; CI now installs pymoose and runs generate_references.py to produce fresh RST class references
- Drop graphviz from docs/requirements.txt
- Gitignore docs/source/references/ (CI-generated, not committed)
- Add Kolkata 2026 one-day workshop content