### PR TITLE
Extend Kolkata 2026 workshop application deadline

### DIFF
--- a/src/content/workshops/onedayworkshop-kolkata2026.md
+++ b/src/content/workshops/onedayworkshop-kolkata2026.md
@@ -26,7 +26,7 @@ CHINTA, 2nd Floor, Tower 1, Bengal Eco Intelligent Park, Block EM, Sector V, Sal
 
 ## Registration form: [Link](https://forms.gle/AMeuMm5Ces2ceEBYA)
 
-## Application Deadline: 21st April 2026, 23:59 IST
+## Application Deadline: 21st April 2026, 23:59 IST [Extended 26th April 2026, 23:59 IST]
 
 ## What to Expect
 


### PR DESCRIPTION
## Summary
- Updates the application deadline for the One-Day Workshop (Kolkata 2026) from 21st April to 26th April 2026, 23:59 IST

## Changes
- `src/content/workshops/onedayworkshop-kolkata2026.md`: Added `[Extended 26th April 2026, 23:59 IST]` to the deadline line

🤖 Generated with [Claude Code](https://claude.com/claude-code)